### PR TITLE
Setup for using Compose Destinations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ import Dependencies.appAuthVersion
 import Dependencies.appCompatVersion
 import Dependencies.arrowVersion
 import Dependencies.chuckerVersion
+import Dependencies.composeDestinationsVersion
 import Dependencies.composeVersion
 import Dependencies.coreKtxVersion
 import Dependencies.daggerVersion
@@ -26,6 +27,7 @@ plugins {
     id("dagger.hilt.android.plugin")
     id("org.jlleitschuh.gradle.ktlint") version(Dependencies.ktLintVersion)
     id("org.jlleitschuh.gradle.ktlint-idea") version(Dependencies.ktLintVersion)
+    id("com.google.devtools.ksp") version(Dependencies.kspVersion)
 }
 
 val CLIENT_SECRET: String by project
@@ -82,6 +84,17 @@ android {
     }
 }
 
+kotlin {
+    sourceSets {
+        debug {
+            kotlin.srcDir("build/generated/ksp/debug/kotlin")
+        }
+        release {
+            kotlin.srcDir("build/generated/ksp/release/kotlin")
+        }
+    }
+}
+
 dependencies {
     implementation("androidx.core:core-ktx:$coreKtxVersion")
     implementation("androidx.appcompat:appcompat:$appCompatVersion")
@@ -111,6 +124,8 @@ dependencies {
     implementation("io.arrow-kt:arrow-core:$arrowVersion")
     debugImplementation("com.github.chuckerteam.chucker:library:$chuckerVersion")
     releaseImplementation("com.github.chuckerteam.chucker:library-no-op:$chuckerVersion")
+    implementation("io.github.raamcosta.compose-destinations:animations-core:$composeDestinationsVersion")
+    ksp("io.github.raamcosta.compose-destinations:ksp:$composeDestinationsVersion")
 
     kapt("com.google.dagger:hilt-compiler:$daggerVersion")
     kapt("com.google.dagger:dagger-compiler:$daggerVersion")

--- a/app/src/main/java/com/yoxjames/openstitch/OpenStitchActivity.kt
+++ b/app/src/main/java/com/yoxjames/openstitch/OpenStitchActivity.kt
@@ -4,11 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.pager.ExperimentalPagerApi
 import com.yoxjames.openstitch.loading.ViewScreen
 import com.yoxjames.openstitch.navigation.Back
 import com.yoxjames.openstitch.navigation.HotPatterns
@@ -25,13 +23,12 @@ import com.yoxjames.openstitch.pattern.vm.list.PatternListView
 import com.yoxjames.openstitch.pattern.vm.list.PatternListViewModel
 import com.yoxjames.openstitch.ui.theme.OpenStitchTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @ExperimentalMaterialApi
-@ExperimentalPagerApi
 @AndroidEntryPoint
 class OpenStitchActivity : ComponentActivity() {
     @Inject lateinit var authenticationManager: AuthenticationManager
@@ -68,13 +65,12 @@ class OpenStitchActivity : ComponentActivity() {
 
     private fun attachUi() {
         setContent {
-            val listState = rememberLazyListState()
             OpenStitchTheme {
                 when (navigationScreenState.collectAsState(HotPatterns).value) {
                     None -> Unit
-                    HotPatterns -> PatternListView(listState, patternListViewModel)
-                    is PatternDetail -> PatternDetailView(patternDetailViewModel)
-                    is SearchingPatterns -> PatternListView(listState, patternListViewModel)
+                    HotPatterns -> PatternListView()
+                    is PatternDetail -> PatternDetailView()
+                    is SearchingPatterns -> PatternListView()
                 }
             }
         }

--- a/app/src/main/java/com/yoxjames/openstitch/core/ContextKtx.kt
+++ b/app/src/main/java/com/yoxjames/openstitch/core/ContextKtx.kt
@@ -1,0 +1,16 @@
+package com.yoxjames.openstitch.core
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+import com.yoxjames.openstitch.OpenStitchActivity
+
+fun <A : ComponentActivity> Context.getActivity(): A = when (this) {
+    is ComponentActivity -> this as? A
+            ?: throw IllegalStateException("Cannot cast ${this::class} to specified AppCompatActivity")
+    is ContextWrapper -> baseContext.getActivity() as? A
+            ?: throw IllegalStateException("Cannot cast ${this::class} to specified AppCompatActivity")
+    else -> throw IllegalStateException("Context cannot be null")
+}
+
+val Context.openStitchActivity: OpenStitchActivity get() = getActivity()

--- a/app/src/main/java/com/yoxjames/openstitch/pattern/vm/detail/PatternDetailView.kt
+++ b/app/src/main/java/com/yoxjames/openstitch/pattern/vm/detail/PatternDetailView.kt
@@ -3,12 +3,15 @@ package com.yoxjames.openstitch.pattern.vm.detail
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
 import com.google.accompanist.pager.ExperimentalPagerApi
+import com.yoxjames.openstitch.core.openStitchActivity
 import com.yoxjames.openstitch.ui.core.OpenStitchScaffold
 
-@ExperimentalPagerApi
+@OptIn(ExperimentalPagerApi::class)
 @Composable
-fun PatternDetailView(viewModel: PatternDetailViewModel) {
+fun PatternDetailView() {
+    val viewModel = LocalContext.current.openStitchActivity.patternDetailViewModel
     val state: PatternDetailScreenState = viewModel.state.collectAsState().value
     val viewState = DetailScreenViewStateMapper(state)
     with(viewState) {

--- a/app/src/main/java/com/yoxjames/openstitch/pattern/vm/detail/PatternDetailViewModel.kt
+++ b/app/src/main/java/com/yoxjames/openstitch/pattern/vm/detail/PatternDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.yoxjames.openstitch.pattern.vm.detail
 
-import com.google.accompanist.pager.ExperimentalPagerApi
 import com.yoxjames.openstitch.core.OpenStitchViewModel
 import com.yoxjames.openstitch.navigation.Back
 import com.yoxjames.openstitch.navigation.NavigationScreenState
@@ -9,9 +8,11 @@ import com.yoxjames.openstitch.navigation.NavigationTransition
 import com.yoxjames.openstitch.navigation.PatternDetail
 import com.yoxjames.openstitch.pattern.ds.PatternDetailDataSource
 import com.yoxjames.openstitch.pattern.state.asState
+import com.yoxjames.openstitch.ui.ActionClick
 import com.yoxjames.openstitch.ui.SearchClick
 import com.yoxjames.openstitch.ui.TopBarBackClick
 import com.yoxjames.openstitch.ui.TopBarSearchViewEvent
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,9 +23,7 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.transform
-import javax.inject.Inject
 
-@ExperimentalPagerApi
 class PatternDetailViewModel @Inject constructor(
     private val patternDetailDataSource: PatternDetailDataSource,
     private val navigationStates: StateFlow<@JvmSuppressWildcards NavigationState>,
@@ -56,6 +55,7 @@ class PatternDetailViewModel @Inject constructor(
         patternDetailViewEvents.collect {
             when (it) {
                 is PatternDetailTopBarViewEvent -> when (it.topBarViewEvent) {
+                    is ActionClick,
                     is TopBarSearchViewEvent,
                     SearchClick -> Unit
                     TopBarBackClick -> navigationBus.emit(Back)

--- a/app/src/main/java/com/yoxjames/openstitch/pattern/vm/list/PatternListView.kt
+++ b/app/src/main/java/com/yoxjames/openstitch/pattern/vm/list/PatternListView.kt
@@ -1,20 +1,22 @@
 package com.yoxjames.openstitch.pattern.vm.list
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
+import com.yoxjames.openstitch.core.openStitchActivity
 import com.yoxjames.openstitch.list.FlowingRow
 import com.yoxjames.openstitch.list.GridView
 import com.yoxjames.openstitch.ui.core.OpenStitchScaffold
 
-@ExperimentalMaterialApi
 @Composable
-fun PatternListView(listState: LazyListState, viewModel: PatternListViewModel) {
-    val plss: PatternListScreenState = viewModel.state.collectAsState().value
-    with(plss) {
+fun PatternListView() {
+    val listState = rememberLazyListState()
+    val viewModel = LocalContext.current.openStitchActivity.patternListViewModel
+    val state: PatternListScreenState = viewModel.state.collectAsState().value
+    with(state) {
         OpenStitchScaffold(
             onTopBarViewEvent = { viewModel.emitViewEvent(PatternListTopBarViewEvent(it)) },
             topBarViewState = searchState.mapToTopBarViewState(),
@@ -35,3 +37,4 @@ fun PatternListView(listState: LazyListState, viewModel: PatternListViewModel) {
         viewModel.start()
     }
 }
+

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,6 +10,7 @@ object Dependencies {
     const val arrowVersion = "1.0.1"
     const val chuckerVersion = "3.5.2"
     const val composeVersion = "1.0.5"
+    const val composeDestinationsVersion = "1.3.4-beta"
     const val coreKtxVersion = "1.7.0"
     const val daggerVersion = "2.40.5"
     const val landscapistVersion = "1.4.5"
@@ -23,4 +24,5 @@ object Dependencies {
     const val timberVersion = "5.0.1"
     const val jUnitVersion = "4.13.2"
     const val ktLintVersion = "10.2.1"
+    const val kspVersion = "$kotlinVersion-1.0.1"
 }


### PR DESCRIPTION
## What does this PR do?

- Adds the dependencies and gradle configuration for [Compose Destinations](https://composedestinations.rafaelcosta.xyz/)
- Refactors the Composables to have no parameters to be ready to switch over to Compose Destinations
  - In order to do this, I had to do 2 things:
    1. Statically access the ViewModels from the Activity. This mimics how people access Android ViewModels via a hilt delegate function. It's not as pretty, and might be a reason to consider moving to Android ViewModels, but it's perfectly sufficient for the moment imo
    2. Moved the `val listState = rememberLazyListState()` into the `PatternListView`. I believe that this shouldn't be a concern, and is actually how it should work to more closely couple the list state with the list. It being called in both instances shouldn't be a concern specifically because it is a remember.
- Not actually using it in this PR, that will be the next one. Mostly wanted to clarify the setup changes. In the next PR I should be able to delete a ton of navigation related code after dropping in a couple lines of Compose Destinations code.